### PR TITLE
duckduckgo has moved to https now

### DIFF
--- a/duckduckgo.py
+++ b/duckduckgo.py
@@ -3,7 +3,7 @@ from lxml import html
 import time
 
 def search(keywords, max_results=None):
-	url = 'http://duckduckgo.com/html/'
+	url = 'https://duckduckgo.com/html/'
 	params = {
 		'q': keywords,
 		's': '0',


### PR DESCRIPTION
DuckDuckGo is now only serving content via https which breaks the script as they return a 301 Permanent move response to https://duckduckgo.com/html/